### PR TITLE
test: expand marketplace helper coverage

### DIFF
--- a/tests/errorHelpers.test.ts
+++ b/tests/errorHelpers.test.ts
@@ -37,6 +37,10 @@ describe("error and invariant helpers", () => {
     expect(success.ok).toBe(true);
     if (success.ok) expect(success.data).toBe(7);
 
+    const successHandler = vi.fn();
+    expect(success.handle(successHandler).ok).toBe(true);
+    expect(successHandler).not.toHaveBeenCalled();
+
     const handler = vi.fn();
     const failure = mayFail(() => {
       throw new Error("failed-sync");

--- a/tests/helperUtilities.test.ts
+++ b/tests/helperUtilities.test.ts
@@ -1,0 +1,150 @@
+import { bytesToHex } from "@helios-lang/codec-utils";
+import { makeAddress } from "@helios-lang/ledger";
+import { makeRandomBip32PrivateKey } from "@helios-lang/tx-utils";
+import { makeConstrData } from "@helios-lang/uplc";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getBlockfrostApi } from "../src/helpers/blockfrost/api.js";
+import { getNetwork } from "../src/helpers/blockfrost/network.js";
+import { get, has, loadEnv } from "../src/helpers/config/index.js";
+import {
+  bigIntMax,
+  bigIntMin,
+  convertTxInputToIUTxO,
+  makeListingTxInputFromListingIUTxO,
+  sleep,
+} from "../src/utils/common.js";
+import { fetchNetworkParameters } from "../src/utils/contract.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+const makeTestAddress = (): string =>
+  makeAddress(false, makeRandomBip32PrivateKey().derivePubKey().hash()).toBech32();
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("configuration helpers", () => {
+  it("loads dotenv files and reads typed env values", () => {
+    const dir = mkdtempSync(join(tmpdir(), "marketplace-config-"));
+    const envPath = join(dir, ".env.test");
+    writeFileSync(envPath, "MARKETPLACE_LABEL=preview\nMARKETPLACE_TIMEOUT=42\n");
+
+    loadEnv({ path: envPath });
+
+    expect(has("MARKETPLACE_LABEL")).toBe(true);
+    const label = get("MARKETPLACE_LABEL", "string");
+    expect(label.ok && label.data).toBe("preview");
+    const timeout = get("MARKETPLACE_TIMEOUT", "number");
+    expect(timeout.ok && timeout.data).toBe(42);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns explicit errors for missing or invalid env values", () => {
+    delete process.env.MARKETPLACE_TIMEOUT;
+    expect(get("MARKETPLACE_TIMEOUT", "string")).toMatchObject({
+      ok: false,
+      error: "MARKETPLACE_TIMEOUT is not set.",
+    });
+
+    process.env.MARKETPLACE_TIMEOUT = "not-a-number";
+    expect(get("MARKETPLACE_TIMEOUT", "number")).toMatchObject({
+      ok: false,
+      error: "MARKETPLACE_TIMEOUT in env is not number type.",
+    });
+  });
+});
+
+describe("blockfrost network helpers", () => {
+  it("detects supported Blockfrost networks from key prefixes", () => {
+    expect(getNetwork("mainnetabcdef")).toBe("mainnet");
+    expect(getNetwork("previewabcdef")).toBe("preview");
+    expect(getNetwork("preprodabcdef")).toBe("preprod");
+  });
+
+  it("rejects unsupported prefixes before constructing a client", () => {
+    expect(() => getNetwork("privateabcdef")).toThrow("Unknown network private");
+    expect(() => getBlockfrostApi("privateabcdef")).toThrow(
+      "Unknown network private"
+    );
+  });
+});
+
+describe("common utility helpers", () => {
+  it("finds bigint bounds across positive and negative values", () => {
+    expect(bigIntMin(7n, -2n, 5n, 0n)).toBe(-2n);
+    expect(bigIntMax(7n, -2n, 5n, 0n)).toBe(7n);
+  });
+
+  it("resolves sleep after the requested timer delay", async () => {
+    vi.useFakeTimers();
+    const settled = vi.fn();
+    const promise = sleep(25).then(settled);
+
+    await vi.advanceTimersByTimeAsync(24);
+    expect(settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it("round-trips listing IUTxOs through TxInput conversion", () => {
+    const listing = {
+      address: makeTestAddress(),
+      tx_id: "ab".repeat(32),
+      index: 3,
+      lovelace: 3_500_000,
+      datum: bytesToHex(makeConstrData(0, []).toCbor()),
+    };
+    const handleHex = Buffer.from("test", "utf8").toString("hex");
+
+    const txInput = makeListingTxInputFromListingIUTxO(listing, handleHex);
+    expect(convertTxInputToIUTxO(txInput)).toEqual(listing);
+
+    const withoutDatum = { ...listing, datum: undefined };
+    const txInputWithoutDatum = makeListingTxInputFromListingIUTxO(
+      withoutDatum,
+      handleHex
+    );
+    expect(convertTxInputToIUTxO(txInputWithoutDatum)).toEqual(withoutDatum);
+  });
+});
+
+describe("contract utility helpers", () => {
+  it("fetches network parameters from the Helios status endpoint", async () => {
+    const fetchMock = vi.fn(async () => ({
+      json: async () => ({ maxTxSize: 16_384 }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchNetworkParameters("preview");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://network-status.helios-lang.io/preview/config"
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual({ maxTxSize: 16_384 });
+  });
+
+  it("wraps network parameter fetch failures as Result errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("status offline");
+      })
+    );
+
+    const result = await fetchNetworkParameters("preprod");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("status offline");
+  });
+});

--- a/tests/transactionError.test.ts
+++ b/tests/transactionError.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { mayFailTransaction } from "../src/helpers/index.js";
+import { BuildTxError } from "../src/types.js";
+import { bigIntMin } from "../src/utils/index.js";
+
+describe("transaction error helpers", () => {
+  const changeAddress = { label: "change-address" };
+  const spareUtxos = [{ id: "spare-utxo" }];
+
+  it("returns the built transaction and dump on success", async () => {
+    const dump = { body: "built" };
+    const tx = {
+      hasValidationError: undefined,
+      dump: () => dump,
+    };
+    const txBuilder = {
+      buildUnsafe: vi.fn(async (options) => {
+        expect(options.changeAddress).toBe(changeAddress);
+        expect(options.spareUtxos).toBe(spareUtxos);
+        expect(options.throwBuildPhaseScriptErrors).toBe(false);
+        options.logOptions.logPrint("ignored success log");
+        return tx;
+      }),
+    };
+
+    const result = await mayFailTransaction(
+      txBuilder as any,
+      changeAddress as any,
+      spareUtxos as any
+    ).complete();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual({ tx, dump });
+  });
+
+  it("wraps validation failures with the failed transaction details", async () => {
+    const handler = vi.fn();
+    const tx = {
+      hasValidationError: new Error("script failed"),
+      dump: () => ({ failed: true }),
+      toCbor: () => new Uint8Array([0xde, 0xad]),
+    };
+    const txBuilder = {
+      buildUnsafe: vi.fn(async ({ logOptions }) => {
+        logOptions.logPrint("first");
+        logOptions.logPrint("second");
+        logOptions.logPrint("third");
+        return tx;
+      }),
+    };
+
+    const result = await mayFailTransaction(
+      txBuilder as any,
+      changeAddress as any,
+      spareUtxos as any
+    )
+      .handle(handler)
+      .complete();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(BuildTxError);
+      expect(result.error.message).toContain("script failed");
+      expect(result.error.message).toContain("Log: first");
+      expect(result.error.message).not.toContain("Log: third");
+      expect(result.error.failedTxCbor).toBe("dead");
+      expect(result.error.failedTxJson).toEqual({ failed: true });
+    }
+    expect(handler).toHaveBeenCalledWith(result.ok ? undefined : result.error);
+  });
+
+  it("uses the latest handler when transaction building throws", async () => {
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+    const txBuilder = {
+      buildUnsafe: vi.fn(async () => {
+        throw new Error("missing inputs");
+      }),
+    };
+
+    const result = await mayFailTransaction(
+      txBuilder as any,
+      changeAddress as any,
+      spareUtxos as any
+    )
+      .handle(firstHandler)
+      .handle(secondHandler)
+      .complete();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error.message).toBe("Tx Build Error: missing inputs");
+    }
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes utility barrel exports used by consumers", () => {
+    expect(bigIntMin(5n, 2n, 9n)).toBe(2n);
+  });
+});


### PR DESCRIPTION
Coverage rotation followed repo-local tooling: package.json maps npm test to vitest run, vitest.config.ts includes tests/**/*.test.*, CI runs npm run test, and test_coverage.sh provides the Vitest V8 plus Aiken diagnostic harness. Added focused tests for deterministic helper/configuration utilities and transaction error handling under tests/helperUtilities.test.ts and tests/transactionError.test.ts, plus a success-handler assertion in tests/errorHelpers.test.ts. Verify passed: npm test from repo root, 51 tests passed. Focused Node coverage diagnostic over the repo-local threshold source list reported lines 99.23%, branches 92.10%, functions 100%, statements 97.79%; the full test_coverage.sh remains blocked by local Aiken v1.1.21 rejecting the repo's Plutus V2 aiken.toml, documented in lesson coverage-rotation-local-tooling-first.